### PR TITLE
Add Gradle configuration cache encryption secret `GRADLE_ENCRYPTION_KEY`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ The following outputs are forwarded from the underlying `setup-java` and `cache`
 
 ## Gradle configuration cache
 
-To enable the Gradle configuration cache, which further improves the build performance, a secret called `GRADLE_ENCRYPTION_KEY` must exist.
+To enable the Gradle configuration cache, which further improves the build performance in addition to the default enabled wrapper/script/dependency/build cache, a GitHub secret called `GRADLE_ENCRYPTION_KEY` must exist.
 If the secret does not exist, Gradle will still work, but the configuration cache will not be saved.
 https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#saving-configuration-cache-data
 

--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,12 @@ The following outputs are forwarded from the underlying `setup-java` and `cache`
 | `path`         | Path to where the java environment has been installed (same as $JAVA_HOME).                                    |
 | `cache-hit`    | A boolean value to indicate an exact match was found for the primary key. (Not applicable when Gradle is used) |
 
+## Gradle configuration cache
+
+To enable the Gradle configuration cache, which further improves the build performance, a secret called `GRADLE_ENCRYPTION_KEY` must exist.
+If the secret does not exist, Gradle will still work, but the configuration cache will not be saved.
+https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#saving-configuration-cache-data
+
 ## Versioning
 
 In order to have a versioning in place and working, create lightweight tags that point to the appropriate minor release

--- a/setup-and-install-with-gradle/action.yml
+++ b/setup-and-install-with-gradle/action.yml
@@ -40,6 +40,7 @@ runs:
       uses: gradle/actions/setup-gradle@v4
       with:
         cache-disabled: ${{ inputs.cache == 'false' }}
+        cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
         cache-read-only: 'false'
 
     - name: Update dependencies

--- a/setup-with-gradle/action.yml
+++ b/setup-with-gradle/action.yml
@@ -40,4 +40,5 @@ runs:
       uses: gradle/actions/setup-gradle@v4
       with:
         cache-disabled: ${{ inputs.cache == 'false' }}
+        cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
         cache-read-only: 'false'


### PR DESCRIPTION
https://github.com/gradle/actions/blob/v4.4.2/docs/setup-gradle.md#saving-configuration-cache-data

Output from one of our projects:
<img width="589" height="49" alt="image" src="https://github.com/user-attachments/assets/15508b0a-daaa-45cd-9e64-ccb8a79aa49c" />

@alexlanz could you also create an organization-wide secret as described here?
https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets#creating-secrets-for-an-organization
https://docs.gradle.org/current/userguide/configuration_cache_requirements.html#config_cache:secrets:configuring_encryption_key